### PR TITLE
CROSSCON-Hypervisor & rpi4-ws: update to next branch with config fixes

### DIFF
--- a/rpi4-ws/configs/rpi4-baremetal/config.c
+++ b/rpi4-ws/configs/rpi4-baremetal/config.c
@@ -1,6 +1,6 @@
 #include <config.h>
 
-VM_IMAGE(bare_image, "../memory-separation/kernel8.img");
+VM_IMAGE(bare_image, "../memory-separation/kernel8.img")
 
 struct vm_config bare = {
     .image = {
@@ -15,7 +15,7 @@ struct vm_config bare = {
     .platform = {
         .cpu_num = 1,
         .region_num = 1,
-        .regions =  (struct mem_region[]) {
+        .regions =  (struct vm_mem_region[]) {
             {
                 .base = 0x20000000,
                 .size = 0x20000000,
@@ -24,20 +24,23 @@ struct vm_config bare = {
             }
         },
         .dev_num = 3,
-        .devs =  (struct dev_region[]) {
+        .devs =  (struct vm_dev_region[]) {
             {
+                .id   = 0,
                 .pa   = 0xfc000000,
                 .va   = 0xfc000000,
                 .size = 0x03000000,
 
             },
             {
+                .id   = 0,
                 .pa   = 0x600000000,
                 .va   = 0x600000000,
                 .size = 0x200000000,
 
             },
             {
+                .id   = 0,
                 /* Arch timer interrupt */
                 .interrupt_num = 1,
                 .interrupts = (irqid_t[]) { 27 }
@@ -53,10 +56,10 @@ struct vm_config bare = {
 };
 
 // Linux Image
-VM_IMAGE(linux_image, "../lloader/linux2-rpi4.bin");
+VM_IMAGE(linux_image, "../lloader/linux2-rpi4.bin")
 
 // Linux VM configuration
-struct vm_config linux = {
+struct vm_config linux_vm = {
     .image = {
         .base_addr = 0x20200000,
         .load_addr = VM_IMAGE_OFFSET(linux_image),
@@ -69,7 +72,7 @@ struct vm_config linux = {
     .platform = {
         .cpu_num = 1,
         .region_num = 1,
-        .regions =  (struct mem_region[]) {
+        .regions =  (struct vm_mem_region[]) {
             {
                 .base = 0x20000000,
                 .size = 0x30000000,
@@ -88,25 +91,29 @@ struct vm_config linux = {
             },
         },
         .dev_num = 4,
-        .devs =  (struct dev_region[]) {
+        .devs =  (struct vm_dev_region[]) {
             {
+                .id   = 0,
                 .pa   = 0xfc000000,
                 .va   = 0xfc000000,
                 .size = 0x03000000,
             },
             {
+                .id   = 0,
                 .pa   = 0x600000000,
                 .va   = 0x600000000,
                 .size = 0x200000000,
 
             },
             {
+                .id   = 0,
                 .interrupt_num = 1,
                 .interrupts = (irqid_t[]) {
                     0x79 + 32 // serial
                 }
             },
             {
+                .id   = 0,
                 /* Arch timer interrupt */
                 .interrupt_num = 2,
                 .interrupts = (irqid_t[]) {
@@ -135,8 +142,8 @@ struct config config = {
         },
     },
     .vmlist_size = 2,
-    .vmlist = {
+    .vmlist = (struct vm_config*[]) {
         &bare,
-        &linux,
+        &linux_vm,
     }
 };

--- a/rpi4-ws/configs/rpi4-minimal-2/config.c
+++ b/rpi4-ws/configs/rpi4-minimal-2/config.c
@@ -1,10 +1,10 @@
 #include <config.h>
 
 // Linux Image
-VM_IMAGE(linux_image, "../lloader/linux-rpi4.bin");
+VM_IMAGE(linux_image, "../lloader/linux-rpi4.bin")
 
 // Linux VM configuration
-struct vm_config linux = {
+struct vm_config linux_vm = {
     .image = {
         .base_addr = 0x20200000,
         .load_addr = VM_IMAGE_OFFSET(linux_image),
@@ -18,33 +18,35 @@ struct vm_config linux = {
     .platform = {
         .cpu_num = 1,
         .region_num = 1,
-        .regions =  (struct mem_region[]) {
+        .regions =  (struct vm_mem_region[]) {
             {
                 .base = 0x20000000,
                 .size = 0x38000000,
             }
         },
         .dev_num = 4,
-        .devs =  (struct dev_region[]) {
+        .devs =  (struct vm_dev_region[]) {
             {
+                .id   = 0,
                 .pa   = 0xfc000000,
                 .va   = 0xfc000000,
                 .size = 0x03000000,
-
             },
             {
+                .id   = 0,
                 .pa   = 0x600000000,
                 .va   = 0x600000000,
                 .size = 0x200000000,
-
             },
             {
+                .id   = 0,
                 .interrupt_num = 1,
                 .interrupts = (irqid_t[]) {
                     0x5d + 32 // serial
                 }
             },
             {
+                .id   = 0,
                 /* Arch timer interrupt */
                 .interrupt_num = 2,
                 .interrupts = (irqid_t[]) {
@@ -63,10 +65,10 @@ struct vm_config linux = {
 };
 
 // Linux Image
-VM_IMAGE(linux_image2, "../lloader/linux2-rpi4.bin");
+VM_IMAGE(linux_image2, "../lloader/linux2-rpi4.bin")
 
 // Linux VM configuration
-struct vm_config linux2 = {
+struct vm_config linux2_vm = {
     .image = {
         .base_addr = 0x20200000,
         .load_addr = VM_IMAGE_OFFSET(linux_image2),
@@ -80,30 +82,34 @@ struct vm_config linux2 = {
     .platform = {
         .cpu_num = 1,
         .region_num = 1,
-        .regions =  (struct mem_region[]) {
+        .regions =  (struct vm_mem_region[]) {
             {
                 .base = 0x20000000,
                 .size = 0x38000000,
             }
         },
         .dev_num = 4,
-        .devs =  (struct dev_region[]) {
+        .devs =  (struct vm_dev_region[]) {
             {
+                .id   = 0,
                 .pa   = 0xfc000000,
                 .va   = 0xfc000000,
                 .size = 0x03000000,
 
             },
             {
+                .id   = 0,
                 .pa   = 0x600000000,
                 .va   = 0x600000000,
                 .size = 0x200000000,
             },
             {
+                .id   = 0,
                 .interrupt_num = 1,
                 .interrupts = (irqid_t[]) { 0x79 + 32 } // serial
             },
             {
+                .id   = 0,
                 /* Arch timer interrupt */
                 .interrupt_num = 2,
                 .interrupts = (irqid_t[]) {
@@ -122,14 +128,14 @@ struct vm_config linux2 = {
 };
 
 struct config config = {
-    CONFIG_HEADER
+    // CONFIG_HEADER
     .shmemlist_size = 1,
     .shmemlist = (struct shmem[]) {
         [0] = {.size = 0x00200000,},
     },
     .vmlist_size = 2,
-    .vmlist = {
-        &linux,
-        &linux2
+    .vmlist = (struct vm_config*[]) {
+        &linux_vm,
+        &linux2_vm
     }
 };

--- a/rpi4-ws/configs/rpi4-minimal/config.c
+++ b/rpi4-ws/configs/rpi4-minimal/config.c
@@ -1,10 +1,10 @@
 #include <config.h>
 
 // Linux Image
-VM_IMAGE(linux_image, "../lloader/linux-rpi4.bin");
+VM_IMAGE(linux_image, "../lloader/linux-rpi4.bin")
 
 // Linux VM configuration
-struct vm_config linux = {
+struct vm_config linux_vm = {
     .image = {
         .base_addr = 0x20200000,
         .load_addr = VM_IMAGE_OFFSET(linux_image),
@@ -17,7 +17,7 @@ struct vm_config linux = {
     .platform = {
         .cpu_num = 1,
         .region_num = 1,
-        .regions =  (struct mem_region[]) {
+        .regions =  (struct vm_mem_region[]) {
             {
                 .base = 0x20000000,
                 .size = 0x40000000,
@@ -36,26 +36,30 @@ struct vm_config linux = {
             },
         },
         .dev_num = 4,
-        .devs =  (struct dev_region[]) {
+        .devs =  (struct vm_dev_region[]) {
             {
+                .id   = 0,
                 .pa   = 0xfc000000,
                 .va   = 0xfc000000,
                 .size = 0x03000000,
 
             },
             {
+                .id   = 0,
                 .pa   = 0x600000000,
                 .va   = 0x600000000,
                 .size = 0x200000000,
 
             },
             {
+                .id   = 0,
                 .interrupt_num = 1,
                 .interrupts = (irqid_t[]) {
                     0x5d + 32 // serial
                 }
             },
             {
+                .id   = 0,
                 /* Arch timer interrupt */
                 .interrupt_num = 2,
                 .interrupts = (irqid_t[]) {
@@ -80,7 +84,7 @@ struct config config = {
         [0] = { .size = 0x00200000, },
     },
     .vmlist_size = 1,
-    .vmlist = {
-        &linux
+    .vmlist = (struct vm_config*[]) {
+        &linux_vm
     }
 };

--- a/rpi4-ws/configs/rpi4-single-vTEE/config.c
+++ b/rpi4-ws/configs/rpi4-single-vTEE/config.c
@@ -1,10 +1,10 @@
 #include <config.h>
 
 // Linux Image
-VM_IMAGE(linux_image, "../lloader/linux-rpi4.bin");
+VM_IMAGE(linux_image, "../lloader/linux-rpi4.bin")
 
 // Linux VM configuration
-struct vm_config linux = {
+struct vm_config linux_vm = {
     .image = {
         .base_addr = 0x20200000,
         .load_addr = VM_IMAGE_OFFSET(linux_image),
@@ -17,7 +17,7 @@ struct vm_config linux = {
     .platform = {
         .cpu_num = 1,
         .region_num = 1,
-        .regions =  (struct mem_region[]) {
+        .regions =  (struct vm_mem_region[]) {
             {
                 .base = 0x20000000,
                 .size = 0x40000000,
@@ -33,8 +33,8 @@ struct vm_config linux = {
                 .shmem_id = 0,
             },
         },
-        .dev_num = 5,
-        .devs =  (struct dev_region[]) {
+        .dev_num = 4,
+        .devs =  (struct vm_dev_region[]) {
             {
                 .pa   = 0xfc000000,
                 .va   = 0xfc000000,
@@ -48,7 +48,7 @@ struct vm_config linux = {
 
             },
             {
-                .interrupt_num = 182,
+                .interrupt_num = 184,
                 .interrupts = (irqid_t[]) {
                     32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 46,
                     47, 48, 49, 50, 51, 52, 53, 54, 55, 56, 57, 58, 59, 60, 61,
@@ -59,21 +59,13 @@ struct vm_config linux = {
                     117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128,
                     129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140,
                     141, 142, 143, 144, 145, 146, 147, 148, 149, 150, 151, 152,
-                    153, 154, 155, 156, 159, 160, 161, 162, 163, 164,
+                    153, 154, 155, 156, 157, 158, 159, 160, 161, 162, 163, 164,
                     165, 166, 167, 168, 169, 170, 171, 172, 173, 174, 175, 176,
                     177, 178, 179, 180, 181, 182, 183, 184, 185, 186, 187, 188,
                     189, 190, 191, 192, 193, 194, 195, 196, 197, 198, 199, 200,
                     201, 202, 203, 204, 205, 206, 207, 208, 209, 210, 211, 212,
                     213, 214, 215, 216, 
                 }
-            },
-            {
-                /* Wired Network Device */
-                .pa = 0x7d580000, // Physical address of the genet device
-                .va = 0x7d580000, // Virtual address for the VM
-                .size = 0x10000,  // Size of the device memory region
-                .interrupt_num = 2,
-                .interrupts = (irqid_t[]) {157, 158} // Interrupts for the network device
             },
             {
                 /* Arch timer interrupt */
@@ -90,7 +82,7 @@ struct vm_config linux = {
     }
 };
 
-VM_IMAGE(optee_os_image, "../optee_os/optee-rpi4/core/tee-pager_v2.bin");
+VM_IMAGE(optee_os_image, "../optee_os/optee-rpi4/core/tee-pager_v2.bin")
 
 
 struct vm_config optee_os = {
@@ -106,11 +98,11 @@ struct vm_config optee_os = {
     .type = 1,
 
     .children_num = 1,
-    .children = (struct vm_config*[]) { &linux },
+    .children = (struct vm_config*[]) { &linux_vm },
     .platform = {
         .cpu_num = 1,
         .region_num = 1,
-        .regions = (struct mem_region[]) {
+        .regions = (struct vm_mem_region[]) {
             {
                 .base = 0x10100000,
                 .size = 0x00F00000, // 15 MB
@@ -127,7 +119,7 @@ struct vm_config optee_os = {
             }
         },
         .dev_num = 1,
-        .devs = (struct dev_region[]) {
+        .devs = (struct vm_dev_region[]) {
             {
                 /* UART1 */
                 .pa = 0xfe215000,
@@ -157,7 +149,7 @@ struct config config = {
         [0] = { .size = 0x00200000, },
     },
     .vmlist_size = 1,
-    .vmlist = {
+    .vmlist = (struct vm_config*[]) {
         &optee_os
     }
 };

--- a/rpi4-ws/create_hyp_img.sh
+++ b/rpi4-ws/create_hyp_img.sh
@@ -23,20 +23,23 @@ patch() {
 
     cd "$ROOT/CROSSCON-Hypervisor"
 
+    for patch_file in "$ROOT/rpi4-ws/patches/hyp/"*.patch; do
     # Check if patch is applied: https://stackoverflow.com/a/66755317
-    set +e
-    git apply --check "$ROOT/rpi4-ws/patches/0001-armv8-aborts.c-add-printk-to-aborts_data_lower.patch" 2>/dev/null
-    git_check_apply=$?
-    git apply --reverse --check "$ROOT/rpi4-ws/patches/0001-armv8-aborts.c-add-printk-to-aborts_data_lower.patch" 2>/dev/null
-    git_check_reverse_apply=$?
-    set -e
+        set +e
+        echo "# Applying $(basename "$patch_file")"
+        sudo -u "$SUDO_USER" git apply --check "$patch_file" 2>/dev/null
+        git_check_apply=$?
+        sudo -u "$SUDO_USER" git apply --reverse --check "$patch_file" 2>/dev/null
+        git_check_reverse_apply=$?
+        set -e
 
-    if [[ $git_check_apply -eq 0 && $git_check_reverse_apply -ne 0 ]]; then
-        git apply "$ROOT/rpi4-ws/patches/0001-armv8-aborts.c-add-printk-to-aborts_data_lower.patch"
-    elif [[ $git_check_apply -ne 0 && $git_check_reverse_apply -ne 0 ]]; then
-        echo "Can't apply patch"
-        exit 1
-    fi
+        if [[ $git_check_apply -eq 0 && $git_check_reverse_apply -ne 0 ]]; then
+            sudo -u "$SUDO_USER" git apply "$patch_file"
+        elif [[ $git_check_apply -ne 0 && $git_check_reverse_apply -ne 0 ]]; then
+            echo "Can't apply patch"
+            exit 1
+        fi
+    done
 
     cd "$ROOT"
 }
@@ -131,12 +134,14 @@ cp -v rpi4-ws/bin/bl31.bin $MOUNT_DIR
 cp -v rpi4-ws/bin/u-boot.bin $MOUNT_DIR
 cp -v lloader/linux*.bin $MOUNT_DIR
 cp -vr rpi4-ws/firmware/boot/start* $MOUNT_DIR
-cp -uv CROSSCON-Hypervisor/bin/rpi4/builtin-configs/$CONFIG_NAME/crossconhyp.bin $MOUNT_DIR
+cp -uv CROSSCON-Hypervisor/bin/rpi4/$CONFIG_NAME/crossconhyp.bin $MOUNT_DIR
 
 echo "# Unmounting the image"
 umount $MOUNT_DIR
 
 echo "# Detaching loop device"
 losetup -d "$LOOP_DEV"
+
+sync
 
 echo "# Done!"

--- a/rpi4-ws/patches/hyp/0001-Makefile-add-Wno-conversion-flag.patch
+++ b/rpi4-ws/patches/hyp/0001-Makefile-add-Wno-conversion-flag.patch
@@ -1,0 +1,29 @@
+From 09ed4946a4bde39a60f8b056553aaaa55f653739 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Micha=C5=82=20Iwanicki?= <michal.iwanicki@3mdeb.com>
+Date: Wed, 22 Oct 2025 11:50:57 +0200
+Subject: [PATCH] Makefile: add -Wno-conversion flag
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Signed-off-by: Michał Iwanicki <michal.iwanicki@3mdeb.com>
+---
+ Makefile | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Makefile b/Makefile
+index d7887f56916b..43b61e7516bb 100644
+--- a/Makefile
++++ b/Makefile
+@@ -321,7 +321,7 @@ else ifeq ($(CC_IS_CLANG), y)
+ endif
+ 
+ override CFLAGS+=-O$(OPTIMIZATIONS) -Wall -Werror -Wextra $(cflags_warns) \
+-	-ffreestanding -std=c11 -fno-pic \
++	-ffreestanding -std=c11 -fno-pic -Wno-conversion \
+ 	$(arch-cflags) $(platform-cflags) $(CPPFLAGS) $(debug_flags)
+ 
+ override ASFLAGS+=$(CFLAGS) $(arch-asflags) $(platform-asflags)
+-- 
+2.47.1
+

--- a/rpi4-ws/patches/hyp/0001-armv8-aborts.c-add-printk-to-aborts_data_lower.patch
+++ b/rpi4-ws/patches/hyp/0001-armv8-aborts.c-add-printk-to-aborts_data_lower.patch
@@ -1,6 +1,6 @@
-From a72abbcc7ba907f5467972b3bd1a04a399bb5596 Mon Sep 17 00:00:00 2001
+From 1735bf0735ddfba805596761bae2b29208e9ea1e Mon Sep 17 00:00:00 2001
 From: =?UTF-8?q?Micha=C5=82=20Iwanicki?= <michal.iwanicki@3mdeb.com>
-Date: Wed, 18 Jun 2025 12:46:22 +0200
+Date: Wed, 22 Oct 2025 11:48:03 +0200
 Subject: [PATCH] armv8: aborts.c: add printk to aborts_data_lower
 MIME-Version: 1.0
 Content-Type: text/plain; charset=UTF-8
@@ -12,15 +12,15 @@ Signed-off-by: Michał Iwanicki <michal.iwanicki@3mdeb.com>
  1 file changed, 3 insertions(+)
 
 diff --git a/src/arch/armv8/aborts.c b/src/arch/armv8/aborts.c
-index a7f5adccf741..294b010db403 100644
+index 8161ef7b72b9..95876789a0ef 100644
 --- a/src/arch/armv8/aborts.c
 +++ b/src/arch/armv8/aborts.c
-@@ -56,6 +56,9 @@ void aborts_data_lower(uint64_t iss, uint64_t far, uint64_t il)
+@@ -31,6 +31,9 @@ static void aborts_data_lower(unsigned long iss, unsigned long far, unsigned lon
  
      vaddr_t addr = far;
-     emul_handler_t handler = vm_emul_get_mem(cpu.vcpu->vm, addr);
+     emul_handler_t handler = vm_emul_get_mem(cpu()->vcpu->vm, addr);
 +    if (addr <= 0xff000000) {
-+        printk("CROSSCONHYP DATA ABORT: 0x%x\n", addr);
++        WARNING("CROSSCONHYP DATA ABORT: 0x%x\n", addr);
 +    }
      if (handler != NULL) {
          struct emul_access emul;


### PR DESCRIPTION
I think docs are out of date: `rpi4-ws/build.sh --steps=10-10`, there are 11 steps so I think it should be `rpi4-ws/build.sh --steps=10-11` or better yet add support for running all steps from `<x>` to the end.

Memory separation test, still freezes, hypervisor enters infinite loop

```
Access (hex): 0x20000000
Trying to access: 0x20000000
Value: 0xff

Access (hex): 0x1fffffff
Trying to access: 0x1fffffff
CROSSCONHYP WARNING: CROSSCONHYP DATA ABORT: 0x1fffffff
CROSSCONHYP WARNING: CROSSCONHYP DATA ABORT: 0x1fffffff
(...)
```

Might be a lack of interrupt handler in baremetal? In Linux it's similar:

```
$ devmem 0x10000000
CROSSCONHYP WARNING: CROSSCONHYP DATA ABORT: 0x10000000
CROSSCONHYP WARNING: CROSSCONHYP DATA ABORT: 0x10000000
```

But i can stop devmem via `CTRL+C`

---

Cache test, issue seems to still be there (and someone either forgot `\n` when printing error or assumed error should've stopped hypervisor from running):

```
CROSSCONHYP ERROR: PSCI cpu3 power down failed with error 4294967295CROSSCONHYP ERROR: PSCI cpu2 power down failed with error 4294967295CROSSCONHYP INFO: Initializing VM0
CROSSCONHYP INFO: Initializing VM 1
CROSSCONHYP ERROR: failed to alloc colored physical pagesCROSSCONHYP INFO: VM 0 adding MMIO region, VA: 0xfc000000 size: 0x3000000 mapped at 0xfc000000
```

